### PR TITLE
Add stack navigation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,8 +36,7 @@ jobs:
         run: yarn run prepare
 
       - name: Run linter
-        # lint only with selene for now since luau-lsp can't ignore issue in luau-polyfill
-        run: yarn run lint:selene
+        run: yarn run lint
 
       - name: Verify code style
         run: yarn run style-check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- add stack navigation capabilities ([#3](https://github.com/seaofvoices/menu-handler/pull/3))
+
 ## 0.1.0
 
 - Initial version

--- a/README.md
+++ b/README.md
@@ -22,7 +22,18 @@ Or if you are using `npm`:
 npm install @crosswalk-game/menu-handler
 ```
 
-## API
+## Content
+
+- [open](#openmenuid-string)
+- [push](#pushmenuid-string)
+- [back](#back)
+- [close](#closemenuid-string)
+- [toggle](#togglemenuid-string)
+- [whileOpened](#whileopenedmenuid-string-effect----teardown----)
+
+- [Tag effects](#tag-effects)
+  - [MenuInstance of MenuExtension](#menuinstance-or-menuextension)
+  - [Menu Navigation](#menu-navigation)
 
 ### `open(menuId: string)`
 
@@ -30,6 +41,19 @@ npm install @crosswalk-game/menu-handler
 
 - **Parameters**:
   - `menuId`: The unique identifier of the menu to open.
+
+### `push(menuId: string)`
+
+- **Description**: Similar to the `open` function: it opens the menu with the specified ID and closes any menu that are not explicitly marked as compatible with the ID.
+
+Additionally, it saves the current menu state into the history stack before opening the new one. Calling [`back`](#back) will return to that state.
+
+- **Parameters**:
+  - `menuId`: The unique identifier of the menu to open.
+
+### `back()`
+
+- **Description**: Go back to the previous menu state from the history stack. State is added in the history stack when calling [`push`](#pushmenuid-string).
 
 ### `close(menuId: string)`
 
@@ -79,7 +103,9 @@ _Optional:_
 
 Optionally, the `MenuInstance` tag effect can also be configured to mark other menus as compatible with itself, by adding string attributes set to other compatible menu `id`. For example, one could add an attribute `compatibleWithStore = "Store"`, where `Store` would be another `MenuInstance` `id`.
 
-### `OpenMenu`, `CloseMenu` or `ToggleMenu`
+### Menu Navigation
+
+There are various tags to navigate through menus: `OpenMenu`, `PushMenu`, `BackMenu`, `CloseMenu` and `ToggleMenu`.
 
 These tag-effects can be used bind a signal to open, close or toggle a menu. They can be applied to any kind of instances:
 
@@ -89,7 +115,7 @@ These tag-effects can be used bind a signal to open, close or toggle a menu. The
 - Any other instance, if the `eventName` attribute is set to an appropriate event name
 
 __Configuration:__
-- `id` (string): identifier of the menu that needs to be opened
+- `id` (string): identifier of the menu that needs to be opened/pushed/closed/toggled. (**excepted** for `BackMenu`, this field is required)
 
 _Optional:_
 - `eventName` (string): specify which signal to use to bind the behavior

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,6 +1,6 @@
 [tools]
-darklua = { github = "seaofvoices/darklua", version = "=0.14.0"}
-luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.34.0"}
+darklua = { github = "seaofvoices/darklua", version = "=0.14.1"}
+luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.36.0"}
 rojo = { github = "rojo-rbx/rojo", version = "=7.4.4"}
 run-in-roblox = { github = "rojo-rbx/run-in-roblox", version = "=0.3.0"}
 selene = { github = "Kampfkarren/selene", version = "=0.27.1"}

--- a/foreman.toml
+++ b/foreman.toml
@@ -1,7 +1,7 @@
 [tools]
-darklua = { github = "seaofvoices/darklua", version = "=0.13.0"}
-luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.28.1"}
-rojo = { github = "rojo-rbx/rojo", version = "=7.4.1"}
+darklua = { github = "seaofvoices/darklua", version = "=0.14.0"}
+luau-lsp = { github = "JohnnyMorganz/luau-lsp", version = "=1.34.0"}
+rojo = { github = "rojo-rbx/rojo", version = "=7.4.4"}
 run-in-roblox = { github = "rojo-rbx/run-in-roblox", version = "=0.3.0"}
-selene = { github = "Kampfkarren/selene", version = "=0.26.1"}
+selene = { github = "Kampfkarren/selene", version = "=0.27.1"}
 stylua = { github = "JohnnyMorganz/StyLua", version = "=0.20.0"}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "url": "git+https://github.com/seaofvoices/menu-handler.git"
   },
   "main": "src/init.lua",
+  "keywords": [
+    "luau"
+  ],
   "scripts": {
     "build": "sh ./scripts/build.sh",
     "clean": "rm -rf node_modules build temp",
@@ -27,13 +30,10 @@
     "@jsdotlua/jest-globals": "^3.6.1-rc.2",
     "npmluau": "^0.1.1"
   },
-  "keywords": [
-    "luau"
-  ],
-  "packageManager": "yarn@4.1.1",
   "dependencies": {
     "@seaofvoices/tag-effect": "^0.1.1",
     "luau-disk": "^0.1.1",
     "luau-teardown": "^0.1.4"
-  }
+  },
+  "packageManager": "yarn@4.5.1"
 }

--- a/scripts/analyze.sh
+++ b/scripts/analyze.sh
@@ -8,6 +8,6 @@ if [ ! -f "$TYPES_FILE" ]; then
     curl https://raw.githubusercontent.com/JohnnyMorganz/luau-lsp/main/scripts/globalTypes.d.lua > $TYPES_FILE
 fi
 
-luau-lsp analyze --base-luaurc=.luaurc --settings=.luau-analyze.json \
+luau-lsp analyze --base-luaurc=.luaurc --settings=.luau-analyze.json --ignore '**/node_modules/**' --ignore 'node_modules/**' \
     --definitions=$TYPES_FILE \
     src

--- a/src/__tests__/init.test.lua
+++ b/src/__tests__/init.test.lua
@@ -90,3 +90,85 @@ it('toggles a menu (closing case)', function()
 
     expect(screenGui.Enabled).toEqual(false)
 end)
+
+it('closes a menu when opening another menu not compatible', function()
+    local firstMenuId = 'screen'
+    local secondMenuId = 'other-screen'
+
+    local firstScreenGui = Instance.new('ScreenGui')
+    firstScreenGui.Enabled = false
+    createMenuInstanceTag(firstMenuId, firstScreenGui)
+    firstScreenGui.Parent = workspace
+
+    local secondScreenGui = Instance.new('ScreenGui')
+    secondScreenGui.Enabled = false
+    createMenuInstanceTag(secondMenuId, secondScreenGui)
+    secondScreenGui.Parent = workspace
+
+    cleanup = { firstScreenGui, secondScreenGui } :: any
+
+    menuHandler.open(firstMenuId)
+    expect(firstScreenGui.Enabled).toEqual(true)
+
+    menuHandler.open(secondMenuId)
+    expect(secondScreenGui.Enabled).toEqual(true)
+    expect(firstScreenGui.Enabled).toEqual(false)
+end)
+
+it('does not re-open a menu after closing a previously opened menu', function()
+    local firstMenuId = 'screen'
+    local secondMenuId = 'other-screen'
+
+    local firstScreenGui = Instance.new('ScreenGui')
+    firstScreenGui.Enabled = false
+    createMenuInstanceTag(firstMenuId, firstScreenGui)
+    firstScreenGui.Parent = workspace
+
+    local secondScreenGui = Instance.new('ScreenGui')
+    secondScreenGui.Enabled = false
+    createMenuInstanceTag(secondMenuId, secondScreenGui)
+    secondScreenGui.Parent = workspace
+
+    cleanup = { firstScreenGui, secondScreenGui } :: any
+
+    menuHandler.open(firstMenuId)
+    expect(firstScreenGui.Enabled).toEqual(true)
+
+    menuHandler.open(secondMenuId)
+    expect(secondScreenGui.Enabled).toEqual(true)
+    expect(firstScreenGui.Enabled).toEqual(false)
+
+    menuHandler.close(secondMenuId)
+
+    expect(secondScreenGui.Enabled).toEqual(false)
+    expect(firstScreenGui.Enabled).toEqual(false)
+end)
+
+it('re-opens a menu after backing from a previously pushed menu', function()
+    local firstMenuId = 'screen'
+    local secondMenuId = 'other-screen'
+
+    local firstScreenGui = Instance.new('ScreenGui')
+    firstScreenGui.Enabled = false
+    createMenuInstanceTag(firstMenuId, firstScreenGui)
+    firstScreenGui.Parent = workspace
+
+    local secondScreenGui = Instance.new('ScreenGui')
+    secondScreenGui.Enabled = false
+    createMenuInstanceTag(secondMenuId, secondScreenGui)
+    secondScreenGui.Parent = workspace
+
+    cleanup = { firstScreenGui, secondScreenGui } :: any
+
+    menuHandler.open(firstMenuId)
+    expect(firstScreenGui.Enabled).toEqual(true)
+
+    menuHandler.push(secondMenuId)
+    expect(secondScreenGui.Enabled).toEqual(true)
+    expect(firstScreenGui.Enabled).toEqual(false)
+
+    menuHandler.back()
+
+    expect(secondScreenGui.Enabled).toEqual(false)
+    expect(firstScreenGui.Enabled).toEqual(true)
+end)


### PR DESCRIPTION
Closes #1 

Add functions to navigate with a history stack:

- `MenuHandler.push`: push a new menu instance in view, but serialize the previous menu state to be able to go back
- `MenuHandler.back`: go back to the previous menu state

Also add 2 new tags to go with these functions `PushMenu` and `BackMenu`

- [x] add entry to the changelog
